### PR TITLE
feat: switch to preset-env instead of es2015

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,13 @@ function webpackConfig(dir, additionalConfig) {
   var config = conf.load();
   var babelOpts = {cacheDirectory: true};
   if (!fs.existsSync(path.join(process.cwd(), '.babelrc'))) {
-    babelOpts.presets = ["es2015"];
+    babelOpts.presets = [
+      ["env", {
+        targets: {
+          node: "6.10"
+        }
+      }]
+    ];
     babelOptsplugins = [
       "transform-class-properties",
       "transform-object-assign",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "base-64": "^0.1.0",
     "body-parser": "^1.18.2",
     "commander": "^2.11.0",


### PR DESCRIPTION
Using preset-env instead of preset-es2015 as recommended by babel.