### PR TITLE
Pass additionalConfig to webpack while watching

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -70,6 +70,6 @@ exports.run = function(dir, additionalConfig) {
 };
 
 exports.watch = function(dir, additionalConfig, cb) {
-  var compiler = webpack(webpackConfig(dir));
-  compiler.watch(webpackConfig(dir), cb);
+  var compiler = webpack(webpackConfig(dir, additionalConfig));
+  compiler.watch(webpackConfig(dir, additionalConfig), cb);
 };


### PR DESCRIPTION
`additionalConfig` isn't supplied to webpack in `serve`. I assume this isn't intentional since the docs state that `-c` is available to both `build` and `serve`.