### PR TITLE
Add "--port" Option

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -17,13 +17,14 @@ program.version(pkg.version);
 
 program
   .option("-c --config <webpack-config>", "additional webpack configuration")
+  .option("-p --port <port>", "port to serve from (default: 9000)")
 
 program
   .command("serve <dir>")
   .description("serve and watch functions")
   .action(function(cmd, options) {
     console.log("Starting server");
-    var server = serve.listen(9000);
+    var server = serve.listen(program.port || 9000);
     build.watch(cmd, program.config, function(err, stats) {
       if (err) {
         console.error(err);


### PR DESCRIPTION
Allows passing an additional command line option `-p <port>` or `--port <port>`, which overrides the default server port of 9000.