### PR TITLE
Ignore favicon

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -66,6 +66,9 @@ exports.listen = function(port) {
   app.use(bodyParser.text({type: "*/*"}));
   app.use(expressLogging(console));
 
+  app.get("/favicon.ico", function(req, res) {
+    res.status(204).end();
+  });
   app.all("*", createHandler(dir));
 
   app.listen(port, function(err) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -64,7 +64,9 @@ exports.listen = function(port) {
   var dir = config.build.functions || config.build.Functions;
   app.use(bodyParser.raw());
   app.use(bodyParser.text({type: "*/*"}));
-  app.use(expressLogging(console));
+  app.use(expressLogging(console, {
+    blacklist: ['/favicon.ico'],
+  }));
 
   app.get("/favicon.ico", function(req, res) {
     res.status(204).end();


### PR DESCRIPTION
* Remove `favicon` request logging
* Remove `favicon` errors

Removes these pesky messages from the console:
```
Request from ::1: GET /favicon.ico
Response with status 500 in 0 ms.
Error during invocation:  { Error: Cannot find module '... /favicon.ico'
```