### PR TITLE
Warn same source

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -22,6 +22,14 @@ function webpackConfig(dir, additionalConfig) {
     ];
   }
 
+  var functionsDir = config.build.functions || config.build.Functions;
+  var functionsPath = path.join(process.cwd(), functionsDir);
+  var dirPath = path.join(process.cwd(), dir);
+
+  if (dirPath === functionsPath) {
+    throw new Error("Function source directory and compiled directory are the same");
+  }
+
   var webpackConfig = {
     module: {
       rules: [
@@ -35,21 +43,18 @@ function webpackConfig(dir, additionalConfig) {
         }
       ]
     },
-    context: path.join(process.cwd(), dir),
+    context: dirPath,
     entry: {},
     target: "node",
     plugins: [new webpack.IgnorePlugin(/vertx/)],
     output: {
-      path: path.join(
-        process.cwd(),
-        config.build.functions || config.build.Functions
-      ),
+      path: functionsPath,
       filename: "[name].js",
       libraryTarget: "commonjs"
     },
     devtool: false
   };
-  fs.readdirSync(path.join(process.cwd(), dir)).forEach(function(file) {
+  fs.readdirSync(dirPath).forEach(function(file) {
     if (file.match(/\.js$/)) {
       var name = file.replace(/\.js$/, "");
       webpackConfig.entry[name] = "./" + name;

--- a/lib/build.js
+++ b/lib/build.js
@@ -27,7 +27,7 @@ function webpackConfig(dir, additionalConfig) {
   var dirPath = path.join(process.cwd(), dir);
 
   if (dirPath === functionsPath) {
-    throw new Error("Function source directory and compiled directory are the same");
+    throw new Error("Function source and publish folder should be in different locations");
   }
 
   var webpackConfig = {


### PR DESCRIPTION
* Add check to see if source and compiled directories are the same

My confusion was due to the fact that the official [code-examples](https://github.com/netlify/code-examples/tree/b2e70ccf151c3f61b157bf3ee40bc6f29997edbc/function_examples/random-word) repo are incorrect.

The messaging can be updated too, I'm not so good with words.

Closes #7 
Closes #18 