### PR TITLE
Include environment variables from config

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -22,6 +22,13 @@ function webpackConfig(dir, additionalConfig) {
     ];
   }
 
+  // Include environment variables from config if available
+  var defineEnv = {};
+  var envConfig = config.build.environment || config.build.Environment || {};
+  Object.keys(envConfig).forEach((key) => {
+    defineEnv["process.env." + key] = JSON.stringify(envConfig[key]);
+  });
+
   var webpackConfig = {
     module: {
       rules: [
@@ -38,7 +45,10 @@ function webpackConfig(dir, additionalConfig) {
     context: path.join(process.cwd(), dir),
     entry: {},
     target: "node",
-    plugins: [new webpack.IgnorePlugin(/vertx/)],
+    plugins: [
+      new webpack.IgnorePlugin(/vertx/),
+      new webpack.DefinePlugin(defineEnv),
+    ],
     output: {
       path: path.join(
         process.cwd(),


### PR DESCRIPTION
On a production lambada, you can access your `netlify.toml` environment variables, but in this package the same isn't available during development, this PR adds the variables from the config on the the `process.env` just like how production works.

* Include `netlify.toml` environment variables