### PR TITLE
Custom Babel env target

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -5,21 +5,23 @@ var webpack = require("webpack");
 var merge = require("webpack-merge");
 
 // custom babel target for each node version
-function getBabelTarget(){
+function getBabelTarget(envConfig){
+  var key = "AWS_LAMBDA_JS_RUNTIME";
   var runtimes = ["nodejs8.10", "nodejs4.3.2", "nodejs6.10.3"];
-  var current = process.env["AWS_LAMBDA_JS_RUNTIME"] || "nodejs6.10.3";
+  var current = envConfig[key] || process.env[key] || "nodejs6.10.3";
   var unknown = runtimes.indexOf(current) === -1;
-  return unknown ? "6.10" : current.replace(/^nodejs/);
+  return unknown ? "6.10" : current.replace(/^nodejs/, '');
 }
 
 function webpackConfig(dir, additionalConfig) {
   var config = conf.load();
+  var envConfig = config.build.environment || config.build.Environment || {};
   var babelOpts = {cacheDirectory: true};
   if (!fs.existsSync(path.join(process.cwd(), '.babelrc'))) {
     babelOpts.presets = [
       ["env", {
         targets: {
-          node: getBabelTarget()
+          node: getBabelTarget(envConfig)
         }
       }]
     ];
@@ -40,7 +42,6 @@ function webpackConfig(dir, additionalConfig) {
   
   // Include environment variables from config if available
   var defineEnv = {};
-  var envConfig = config.build.environment || config.build.Environment || {};
   Object.keys(envConfig).forEach((key) => {
     defineEnv["process.env." + key] = JSON.stringify(envConfig[key]);
   });

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,6 +4,14 @@ var conf = require("./config");
 var webpack = require("webpack");
 var merge = require("webpack-merge");
 
+// custom babel target for each node version
+function getBabelTarget(){
+  var runtimes = ["nodejs8.10", "nodejs4.3.2", "nodejs6.10.3"];
+  var current = process.env["AWS_LAMBDA_JS_RUNTIME"] || "nodejs6.10.3";
+  var unknown = runtimes.indexOf(current) === -1;
+  return unknown ? "6.10" : current.replace(/^nodejs/);
+}
+
 function webpackConfig(dir, additionalConfig) {
   var config = conf.load();
   var babelOpts = {cacheDirectory: true};
@@ -11,7 +19,7 @@ function webpackConfig(dir, additionalConfig) {
     babelOpts.presets = [
       ["env", {
         targets: {
-          node: "6.10"
+          node: getBabelTarget()
         }
       }]
     ];


### PR DESCRIPTION
determine node target based on `AWS_LAMBDA_JS_RUNTIME`.

defaults to `6.10` because:
- safety (it's forwards compatible)
- this value was hardcoded before the change

---

question: should `process.env` be counted as env?