### PR TITLE
allowing requests from any origin

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -84,6 +84,15 @@ exports.listen = function(port) {
   app.use(expressLogging(console, {
     blacklist: ['/favicon.ico'],
   }));
+  
+  app.use((req, res, next) => {
+    res.header(`Access-Control-Allow-Origin`, `*`)
+    res.header(
+      `Access-Control-Allow-Headers`,
+      `Origin, X-Requested-With, Content-Type, Accept`
+    )
+    next()
+  })
 
   app.get("/favicon.ico", function(req, res) {
     res.status(204).end();


### PR DESCRIPTION
Had some issues with local development requests not working due to cross-origin calls. Adding a request header to allow them relieved any issues.



