### PR TITLE
Match body size limit to AWS

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -79,8 +79,8 @@ exports.listen = function(port) {
   var config = conf.load();
   var app = express();
   var dir = config.build.functions || config.build.Functions;
-  app.use(bodyParser.raw());
-  app.use(bodyParser.text({type: "*/*"}));
+  app.use(bodyParser.raw({limit: "10mb"}));
+  app.use(bodyParser.text({limit: "10mb", type: "*/*"}));
   app.use(expressLogging(console, {
     blacklist: ['/favicon.ico'],
   }));

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -79,8 +79,8 @@ exports.listen = function(port) {
   var config = conf.load();
   var app = express();
   var dir = config.build.functions || config.build.Functions;
-  app.use(bodyParser.raw({limit: "10mb"}));
-  app.use(bodyParser.text({limit: "10mb", type: "*/*"}));
+  app.use(bodyParser.raw({limit: "6mb"}));
+  app.use(bodyParser.text({limit: "6mb", type: "*/*"}));
   app.use(expressLogging(console, {
     blacklist: ['/favicon.ico'],
   }));


### PR DESCRIPTION
This small PR sets the size limit of the body parser to match what AWS supports.