### PR TITLE
Support common alternative extensions for entries.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -74,8 +74,8 @@ function webpackConfig(dir, additionalConfig) {
     devtool: false
   };
   fs.readdirSync(dirPath).forEach(function(file) {
-    if (file.match(/\.js$/)) {
-      var name = file.replace(/\.js$/, "");
+    if (file.match(/\.(m?js|ts)$/)) {
+      var name = file.replace(/\.(m?js|ts)$/, "");
       webpackConfig.entry[name] = "./" + name;
     }
   });


### PR DESCRIPTION
This adds support for constructing entries from `.js`, `.mjs`, and `.ts` files. For the time being it is still up to users to define loaders and resolution rules for these extensions. It will also be up to users to define typings for TypeScript entries though I may put some in a future PR.