### PR TITLE
Add `output` option to build command

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -41,11 +41,12 @@ program
 
 program
   .command("build <dir>")
+  .option('-o, --output <outputDirectory>', 'Output directory for built functions')
   .description("build functions")
   .action(function(cmd, options) {
     console.log("Building functions");
     build
-      .run(cmd, program.config)
+      .run(cmd, program.config, options)
       .then(function(stats) {
         console.log(stats.toString({ color: true }));
       })

--- a/lib/build.js
+++ b/lib/build.js
@@ -13,7 +13,7 @@ function getBabelTarget(envConfig){
   return unknown ? "6.10" : current.replace(/^nodejs/, '');
 }
 
-function webpackConfig(dir, additionalConfig) {
+function webpackConfig(dir, additionalConfig, cmdOptions) {
   var config = conf.load();
   var envConfig = config.build.environment || config.build.Environment || {};
   var babelOpts = {cacheDirectory: true};
@@ -32,20 +32,24 @@ function webpackConfig(dir, additionalConfig) {
     ];
   }
 
-  var functionsDir = config.build.functions || config.build.Functions;
-  var functionsPath = path.join(process.cwd(), functionsDir);
+  var functionsSourceDir = config.build.functions || config.build.Functions;
+  // Use --output flag if provided OR use original functions dir name
+  var outputDirectory = cmdOptions.output || functionsSourceDir
+  var functionsOutputPath = path.join(process.cwd(), outputDirectory);
+  // console.log('Building functions to', functionsOutputPath)
+
   var dirPath = path.join(process.cwd(), dir);
 
-  if (dirPath === functionsPath) {
+  if (dirPath === functionsOutputPath) {
     throw new Error("Function source and publish folder should be in different locations");
   }
-  
+
   // Include environment variables from config if available
   var defineEnv = {};
   Object.keys(envConfig).forEach((key) => {
     defineEnv["process.env." + key] = JSON.stringify(envConfig[key]);
   });
-  
+
   var webpackConfig = {
     module: {
       rules: [
@@ -67,7 +71,7 @@ function webpackConfig(dir, additionalConfig) {
       new webpack.DefinePlugin(defineEnv),
     ],
     output: {
-      path: functionsPath,
+      path: functionsOutputPath,
       filename: "[name].js",
       libraryTarget: "commonjs"
     },
@@ -88,9 +92,9 @@ function webpackConfig(dir, additionalConfig) {
   return webpackConfig;
 }
 
-exports.run = function(dir, additionalConfig) {
+exports.run = function(dir, additionalConfig, cmdOptions) {
   return new Promise(function(resolve, reject) {
-    webpack(webpackConfig(dir, additionalConfig), function(err, stats) {
+    webpack(webpackConfig(dir, additionalConfig, cmdOptions), function(err, stats) {
       if (err) {
         return reject(err);
       }


### PR DESCRIPTION
Adding `output` option to `netlify-lambda build`. This gives a way to build my functions from the top level of my project into a git-ignored build-directory for netlify to consume.

Usage:

```
netlify-lambda build functions --output functions-build
# or 
netlify-lambda build functions -o functions-build
```

![custom output dir name](https://user-images.githubusercontent.com/532272/41134876-859781a2-6a83-11e8-8fa8-08a0b80f0f49.gif)

In netlify.toml I then point to `functions-build`

```toml
[build]
  Functions = "functions-build"
```
