### PR TITLE
add support for http-server

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -45,7 +45,10 @@ function promiseCallback(promise, callback) {
 
 function createHandler(dir) {
   return function(request, response) {
-    var func = request.path.split("/").filter(function(e) {
+    // handle proxies without path re-writes (http-servr)
+    var cleanPath = request.path.replace(/^\/.netlify\/functions/, '')
+
+    var func = cleanPath.split("/").filter(function(e) {
       return e;
     })[0];
     var module = path.join(process.cwd(), dir, func);


### PR DESCRIPTION
Adding support for `http-server` package https://www.npmjs.com/package/http-server

```
{
  "name": "site-xyz",
  "scripts": {
    "start:site": "http-server src --proxy http://localhost:9000/",
    "start:functions": "netlify-lambda serve functions",
    "start": "npm-run-all --parallel start:**",
    "build": "netlify-lambda build functions"
  },
  "devDependencies": {
    "http-server": "^0.11.1",
    "netlify-lambda": "^0.4.0",
    "npm-run-all": "^4.1.3"
  }
}
```

This PR cleans leading `/.netlify/functions` path from incoming proxy requests so the correct function function path is loaded.

Without it the package throws this error because of how it looks for function names

```
{ Error: Cannot find module '/Users/davidwells/Netlify/scratch/progressive-enhancement-form-functions/functions-build/.netlify'
```