### PR TITLE
inject clientContext to served function on dev-server

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -4,6 +4,7 @@ var expressLogging = require("express-logging");
 var path = require("path");
 var base64 = require("base-64");
 var conf = require("./config");
+var jwtDecode = require("jwt-decode")
 
 function handleErr(err, response) {
   response.statusCode = 500;
@@ -70,7 +71,17 @@ function createHandler(dir) {
     };
 
     var callback = createCallback(response);
-    var promise = handler.handler(lambdaRequest, {}, callback);
+    let clientContext = {}
+    if (request.headers['authorization']) {
+      const parts = request.headers['authorization'].split(' ')
+      if (parts.length === 2 && parts[0] === 'Bearer') {
+        clientContext = {
+          identity: { url: '', token: '' },
+          user: jwtDecode(parts[1])
+        }
+      }
+    }
+    var promise = handler.handler(lambdaRequest, { clientContext }, callback);
     promiseCallback(promise, callback);
   };
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "commander": "^2.11.0",
     "express": "^4.16.2",
     "express-logging": "^1.1.1",
+    "jwt-decode": "^2.2.0",
     "toml": "^2.3.3",
     "webpack": "^3.8.1",
     "webpack-merge": "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,6 +1794,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
Inject decoded information to served function on dev-server as same as production.
Actually it's difficult to verify access_token, so it's only inject decoded information.
but I think that is enough on development to check Netlify identify roles.
