### PR TITLE
Added "-s --static" option to prevent building of files

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -18,6 +18,7 @@ program.version(pkg.version);
 program
   .option("-c --config <webpack-config>", "additional webpack configuration")
   .option("-p --port <port>", "port to serve from (default: 9000)")
+  .option("-s --static", "serve pre-built lambda files")
 
 program
   .command("serve <dir>")
@@ -25,6 +26,10 @@ program
   .action(function(cmd, options) {
     console.log("Starting server");
     var server = serve.listen(program.port || 9000);
+    var static = Boolean(program.static);
+    if(static) {
+      return
+    }
     build.watch(cmd, program.config, function(err, stats) {
       if (err) {
         console.error(err);

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -25,8 +25,8 @@ program
   .description("serve and watch functions")
   .action(function(cmd, options) {
     console.log("Starting server");
-    var server = serve.listen(program.port || 9000);
     var static = Boolean(program.static);
+    var server = serve.listen(program.port || 9000, static);
     if(static) {
       return
     }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -43,12 +43,15 @@ function promiseCallback(promise, callback) {
   );
 }
 
-function createHandler(dir) {
+function createHandler(dir, static) {
   return function(request, response) {
     var func = request.path.split("/").filter(function(e) {
       return e;
     })[0];
     var module = path.join(process.cwd(), dir, func);
+    if(static) {
+      delete require.cache[require.resolve(module)]
+    }
     var handler;
     try {
       handler = require(module);
@@ -75,7 +78,7 @@ function createHandler(dir) {
   };
 }
 
-exports.listen = function(port) {
+exports.listen = function(port, static) {
   var config = conf.load();
   var app = express();
   var dir = config.build.functions || config.build.Functions;
@@ -88,7 +91,7 @@ exports.listen = function(port) {
   app.get("/favicon.ico", function(req, res) {
     res.status(204).end();
   });
-  app.all("*", createHandler(dir));
+  app.all("*", createHandler(dir, static));
 
   app.listen(port, function(err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-lambda",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Build and serve lambda function with webpack compilation",
   "homepage": "https://github.com/netlify/netlify-lambda#readme",
   "main": "bin/cmd.js",


### PR DESCRIPTION
As to be expected, my webpack config / version is incompatible with the `netlify-lambda` package - this option prevents the entire build process and puts the responsibility back on the caller.

Additionally, the require cache is cleared each time the function is called.

By default there is no change in functionality and this change _should_ be completely backwards compatible.

**Usage**
```
npx netlify-lambda serve <folder> -s
```