### PR TITLE
fixed querystring parsing netlify/netlify-lambda#54

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,6 +1,7 @@
 var express = require("express");
 var bodyParser = require("body-parser");
 var expressLogging = require("express-logging");
+var queryString = require("querystring");
 var path = require("path");
 var base64 = require("base-64");
 var conf = require("./config");
@@ -69,7 +70,7 @@ function createHandler(dir, static) {
     var lambdaRequest = {
       path: request.path,
       httpMethod: request.method,
-      queryStringParameters: request.query,
+      queryStringParameters: queryString.parse(request.url.split("?")[1]),
       headers: request.headers,
       body: isBase64 ? base64.encode(request.body) : request.body,
       isBase64Encoded: isBase64


### PR DESCRIPTION
As the commit suggests.

_Additionally, attempting to parse `undefined` will return an empty object._