### PR TITLE
Removed base-64 package in favour of node Buffer

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -3,7 +3,6 @@ var bodyParser = require("body-parser");
 var expressLogging = require("express-logging");
 var queryString = require("querystring");
 var path = require("path");
-var base64 = require("base-64");
 var conf = require("./config");
 
 function handleErr(err, response) {
@@ -26,7 +25,7 @@ function createCallback(response) {
     }
     response.write(
       lambdaResponse.isBase64Encoded
-        ? base64.decode(lambdaResponse.body)
+        ? Buffer.from(lambdaResponse.body, "base64")
         : lambdaResponse.body
     );
     response.end();
@@ -72,7 +71,7 @@ function createHandler(dir, static) {
       httpMethod: request.method,
       queryStringParameters: queryString.parse(request.url.split("?")[1]),
       headers: request.headers,
-      body: isBase64 ? base64.encode(request.body) : request.body,
+      body: isBase64 ? Buffer.from(request.body.toString(), "utf8").toString('base64') : request.body,
       isBase64Encoded: isBase64
     };
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -34,8 +34,8 @@ function createCallback(response) {
 
 function promiseCallback(promise, callback) {
   if (!promise) return;
-  if (typeof promise.then !== 'function') return;
-  if (typeof callback !== 'function') return;
+  if (typeof promise.then !== "function") return;
+  if (typeof callback !== "function") return;
 
   promise.then(
     function(data) {callback(null, data)},
@@ -46,7 +46,7 @@ function promiseCallback(promise, callback) {
 function createHandler(dir, static) {
   return function(request, response) {
     // handle proxies without path re-writes (http-servr)
-    var cleanPath = request.path.replace(/^\/.netlify\/functions/, '')
+    var cleanPath = request.path.replace(/^\/.netlify\/functions/, "")
 
     var func = cleanPath.split("/").filter(function(e) {
       return e;
@@ -71,7 +71,7 @@ function createHandler(dir, static) {
       httpMethod: request.method,
       queryStringParameters: queryString.parse(request.url.split("?")[1]),
       headers: request.headers,
-      body: isBase64 ? Buffer.from(request.body.toString(), "utf8").toString('base64') : request.body,
+      body: isBase64 ? Buffer.from(request.body.toString(), "utf8").toString("base64") : request.body,
       isBase64Encoded: isBase64
     };
 
@@ -88,7 +88,7 @@ exports.listen = function(port, static) {
   app.use(bodyParser.raw({limit: "6mb"}));
   app.use(bodyParser.text({limit: "6mb", type: "*/*"}));
   app.use(expressLogging(console, {
-    blacklist: ['/favicon.ico'],
+    blacklist: ["/favicon.ico"],
   }));
 
   app.get("/favicon.ico", function(req, res) {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-object-assign": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "base-64": "^0.1.0",
     "body-parser": "^1.18.3",
     "commander": "^2.17.1",
     "express": "^4.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,10 +853,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base-64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"


### PR DESCRIPTION
I haven't read much about the [base-64 package](https://www.npmjs.com/package/base-64) but it's usage in **netlify-lambda** must be incorrect or not doing what's expected.

Switched to node `Buffer` instead and _afaict_ it should be doing the same thing, but for whatever reason `Buffer` works and `base-64` doesn't 🤷‍♂️

#26 