### PR TITLE
Ignore what `require.resolve` throws when module not found.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -109,7 +109,9 @@ exports.listen = function(port, static) {
   return {
     clearCache: function(chunk) {
       var module = path.join(process.cwd(), dir, chunk);
-      delete require.cache[require.resolve(module)];
+      try {
+        delete require.cache[require.resolve(module)];
+      } catch (e) { }
     }
   };
 };


### PR DESCRIPTION
Closes https://github.com/netlify/create-react-app-lambda/issues/7