### PR TITLE
Support extensions: .mjs and .ts

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -50,7 +50,7 @@ function webpackConfig(dir, additionalConfig) {
     module: {
       rules: [
         {
-          test: /\.js?$/,
+          test: /\.(m?js|ts)?$/,
           exclude: /(node_modules|bower_components)/,
           use: {
             loader: "babel-loader",
@@ -74,9 +74,9 @@ function webpackConfig(dir, additionalConfig) {
     devtool: false
   };
   fs.readdirSync(dirPath).forEach(function(file) {
-    if (file.match(/\.js$/)) {
-      var name = file.replace(/\.js$/, "");
-      webpackConfig.entry[name] = "./" + name;
+    if (file.match(/\.(m?js|ts)$/)) {
+      var name = file.replace(/\.(js|ts)$/, "");
+      webpackConfig.entry[name] = "./" + file;
     }
   });
   if (additionalConfig) {


### PR DESCRIPTION
Fix #39. I would like to use TypeScript in netlify-lambda!

This PR added for `.ts` and `.mjs` extensions. I changed webpack config.

## TypeScript sample
In order to use TypeScript, you need to install `@babel/preset-typescript` and define `.babelrc` as follows.

```diff
{
  "presets": [
+   "@babel/preset-typescript",
    [
      "@babel/preset-env",
      {
        "targets": {
          "node": "6.10.3"
        }
      }
    ]
  ],
  "plugins": [
    "@babel/plugin-proposal-class-properties",
    "@babel/plugin-transform-object-assign",
    "@babel/plugin-proposal-object-rest-spread"
  ]
}
```