### PR TITLE
Fix build `.mjs` filename

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -75,7 +75,7 @@ function webpackConfig(dir, additionalConfig) {
   };
   fs.readdirSync(dirPath).forEach(function(file) {
     if (file.match(/\.(m?js|ts)$/)) {
-      var name = file.replace(/\.(js|ts)$/, "");
+      var name = file.replace(/\.(m?js|ts)$/, "");
       webpackConfig.entry[name] = "./" + file;
     }
   });


### PR DESCRIPTION
I have a mistake(#76), so I fixed.

## Steps to reproduce
* function directory in netlify.toml: `functions/`
* Create file: `src/function.mjs`
* Use this command `netlify-lambda build src/`

### Expected result
Build filename is `functions/function.mjs.js`

### Actual result
Build filename is `functions/function.js`