### PR TITLE
Add .ts to resolve.extensions

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -47,6 +47,9 @@ function webpackConfig(dir, additionalConfig) {
 
   var webpackConfig = {
     mode: "production",
+    resolve: {
+      extensions: ['.js', '.mjs', '.ts']
+    },
     module: {
       rules: [
         {

--- a/lib/build.js
+++ b/lib/build.js
@@ -48,7 +48,7 @@ function webpackConfig(dir, additionalConfig) {
   var webpackConfig = {
     mode: "production",
     resolve: {
-      extensions: ['.js', '.mjs', '.ts']
+      extensions: ['.wasm', '.mjs', '.js', '.json', '.ts']
     },
     module: {
       rules: [


### PR DESCRIPTION
@sw-yx Please check this.

Fix #79. I add '.ts' to resolve.extensions, so we can use these extensions as import.

refs. https://webpack.js.org/configuration/resolve/#resolve-extensions

## Test
in Application directory with lambda

```bash
$ yarn add -D @babel-preset-typescript
$ ../netlify-lambda/bin/cmd.js build src/
```

netlify.toml
```toml
[build]
  functions = "functions"
  publish = "public"
  command = "npm run build"
```

.babelrc
```json
{
  "presets": [
    "@babel/preset-typescript",
    [
      "@babel/preset-env",
      {
        "targets": {
          "node": "6.10.3"
        }
      }
    ]
  ],
  "plugins": [
    "@babel/plugin-proposal-class-properties",
    "@babel/plugin-transform-object-assign",
    "@babel/plugin-proposal-object-rest-spread"
  ]
}
```