### PR TITLE
Proposal: add warning if no function files found

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -82,6 +82,17 @@ function webpackConfig(dir, additionalConfig) {
       webpackConfig.entry[name] = "./" + file;
     }
   });
+  if (Object.keys(webpackConfig.entry) < 1) {
+    console.warn(
+      `
+      ---Start netlify-lambda notification---
+      WARNING: No valid single functions files (ending in .mjs, .js or .ts) were found. 
+      This could be because you have nested them in a folder.
+      If this is expected (e.g. you have a zipped function built somewhere else), you may ignore this.
+      ---End netlify-lambda notification---
+      `
+    );
+  }
   if (additionalConfig) {
     var webpackAdditional = require(path.join(process.cwd(), additionalConfig));
 


### PR DESCRIPTION
this PR makes the console output a bit more helpful when you dont have a valid file in your functions folder, e.g you have nested a folder like `functions/hello/hello.js` instead of `functions/hello.js`.

this mistake will cause a cryptic warning like:

```bash

/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/node_modules/webpack/lib/webpack.js:31
                throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
                ^

WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.entry should be one of these:
   function | object { <key>: non-empty string | [non-empty string] } | non-empty string | [non-emptystring]
   -> The entry point(s) of the compilation.
   Details:
    * configuration.entry should be an instance of function
      -> A Function returning an entry object, an entry string, an entry array or a promise to these things.
    * configuration.entry should not be empty.
      -> Multiple entry bundles are created. The key is the chunk name. The value can be a string or an array.
    * configuration.entry should be a string.
      -> An entry point without name. The string is resolved to a module which is loaded upon startup.
    * configuration.entry should be an array:
      [non-empty string]
    at webpack (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/node_modules/webpack/lib/webpack.js:31:9)
    at Object.exports.watch (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/lib/build.js:117:18)
    at Command.<anonymous> (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/bin/cmd.js:31:11)
    at Command.listener (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/node_modules/commander/index.js:315:8)
    at Command.emit (events.js:182:13)
    at Command.parseArgs (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/node_modules/commander/index.js:654:12)
    at Command.parse (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/Users/swyx/Work/hooks-suspense-faunadb-todo/node_modules/netlify-lambda/bin/cmd.js:61:9)
    at Module._compile (internal/modules/cjs/loader.js:707:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:718:10)
error Command failed with exit code 1.
```

just trying to make the DX a bit better here by hinting at what's wrong.

what do folks think?