### PR TITLE
Fix 'queryStringParameters' when the url contains multiple question marks

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -69,7 +69,7 @@ function createHandler(dir, static) {
     var lambdaRequest = {
       path: request.path,
       httpMethod: request.method,
-      queryStringParameters: queryString.parse(request.url.split("?")[1]),
+      queryStringParameters: queryString.parse(request.url.split(/\?(.+)/)[1]),
       headers: request.headers,
       body: isBase64 ? Buffer.from(request.body.toString(), "utf8").toString("base64") : request.body,
       isBase64Encoded: isBase64


### PR DESCRIPTION
This fix is related to the issue #54.

Given a request that looks something like this:
```sh
?url=https://www.youtube.com/watch?v=0uwe_PhCRcY&filter[0][field]=title&filter[0][value]=TestElement
```

The value of `event.queryStringParameters` should be an object like this:
```json
{
    "url" : "https://www.youtube.com/watch?v=0uwe_PhCRcY",
    "filter[0][field]" : "title",
    "filter[0][value]" : "TestElement"
}
```

Instead of the following object:
```json
{
    "url": "https://m.youtube.com/watch"
}
```