### PR TITLE
Crawl up directories to find config, to support monorepos

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -3,6 +3,7 @@ var path = require("path");
 var conf = require("./config");
 var webpack = require("webpack");
 var merge = require("webpack-merge");
+var findUp = require('find-up');
 
 // custom babel target for each node version
 function getBabelTarget(envConfig) {
@@ -14,10 +15,12 @@ function getBabelTarget(envConfig) {
 }
 
 function webpackConfig(dir, additionalConfig) {
-  var config = conf.load();
+  var allConfig = conf.load();
+  var config = allConfig.config;
+  var rootPath = allConfig.rootPath;
   var envConfig = config.build.environment || config.build.Environment || {};
   var babelOpts = { cacheDirectory: true };
-  if (!fs.existsSync(path.join(process.cwd(), ".babelrc"))) {
+  if (!findUp.sync(".babelrc")) {
     babelOpts.presets = [
       ["@babel/preset-env", { targets: { node: getBabelTarget(envConfig) } }]
     ];
@@ -30,7 +33,7 @@ function webpackConfig(dir, additionalConfig) {
   }
 
   var functionsDir = config.build.functions || config.build.Functions;
-  var functionsPath = path.join(process.cwd(), functionsDir);
+  var functionsPath = path.join(rootPath, functionsDir);
   var dirPath = path.join(process.cwd(), dir);
 
   if (dirPath === functionsPath) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,11 @@
 var toml = require("toml");
 var fs = require("fs");
 var path = require("path");
+var findUp = require('find-up');
+var path = require('path');
 
 exports.load = function() {
-  var configPath = path.join(process.cwd(), "netlify.toml");
+  var configPath = findUp.sync("netlify.toml");
   if (!fs.existsSync(configPath)) {
     console.error(
       "No netlify.toml found. This is needed to configure the function settings"
@@ -11,5 +13,8 @@ exports.load = function() {
     process.exit(1);
   }
 
-  return toml.parse(fs.readFileSync(configPath));
+  return {
+    config: toml.parse(fs.readFileSync(configPath)),
+    rootPath: path.join(configPath, '..'),
+  };
 };

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -51,7 +51,7 @@ function createHandler(dir, static) {
     var func = cleanPath.split("/").filter(function(e) {
       return e;
     })[0];
-    var module = path.join(process.cwd(), dir, func);
+    var module = path.join(dir, func);
     if(static) {
       delete require.cache[require.resolve(module)]
     }
@@ -82,9 +82,14 @@ function createHandler(dir, static) {
 }
 
 exports.listen = function(port, static) {
-  var config = conf.load();
+  var allConfig = conf.load();
+  var config = allConfig.config;
+  var rootPath = allConfig.rootPath;
+
   var app = express();
-  var dir = config.build.functions || config.build.Functions;
+  var relativeDir = config.build.functions || config.build.Functions;
+  var dir = path.join(rootPath, relativeDir);
+
   app.use(bodyParser.raw({limit: "6mb"}));
   app.use(bodyParser.text({limit: "6mb", type: "*/*"}));
   app.use(expressLogging(console, {
@@ -107,7 +112,7 @@ exports.listen = function(port, static) {
 
   return {
     clearCache: function(chunk) {
-      var module = path.join(process.cwd(), dir, chunk);
+      var module = path.join(dir, chunk);
       delete require.cache[require.resolve(module)];
     }
   };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commander": "^2.17.1",
     "express": "^4.16.3",
     "express-logging": "^1.1.1",
+    "find-up": "^3.0.0",
     "toml": "^2.3.3",
     "webpack": "^4.17.1",
     "webpack-merge": "^4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,6 +1600,12 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
+
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
@@ -2079,6 +2085,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -2477,11 +2490,27 @@ p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
 
+p-limit@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.1.0.tgz#1d5a0d20fb12707c758a655f6bbc4386b5930d68"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 pako@~0.2.0:
   version "0.2.9"


### PR DESCRIPTION
This change will crawl up the directories to find the first netlify.toml relative to the current working directory, instead of just testing the current directory. This is important for monorepos because the netlify servers expect the netlify.toml in the root directory. If the command is run with the current working directory set to monorepo package like ``packages/my-package``, the command will currently fail to find a config file.

It's possible that the .babelrc portion of this change could break existing workflows where there are environments with an incompatible .babelrc file in a parent directory.