### PR TITLE
Accept environment variable overrides from config file

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -16,6 +16,17 @@ function getBabelTarget(envConfig) {
 function webpackConfig(dir, additionalConfig) {
   var config = conf.load();
   var envConfig = config.build.environment || config.build.Environment || {};
+
+  var action = process.env.CONTEXT;
+  var build = config.build || {};
+  var context = config.context || {};
+  var overrides = context[action] || {};
+
+  var envConfig = Object.assign(
+    {},
+    build.environment || build.Environment || {},
+    overrides.environment || overrides.Environment || {},
+  );
   var babelOpts = { cacheDirectory: true };
   if (!fs.existsSync(path.join(process.cwd(), ".babelrc"))) {
     babelOpts.presets = [


### PR DESCRIPTION
This allows for overriding the "build" scoped environment variables with other contexts, such as branch-deploy or deploy-preview.

It's possible this could break existing workflows if people are relying on environment variables set in the other contexts **not working**. This seems like a bug to me, but it's worth noting.