### PR TITLE
Allow reponse body to be optional

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -24,11 +24,14 @@ function createCallback(response) {
     for (const key in lambdaResponse.headers) {
       response.setHeader(key, lambdaResponse.headers[key]);
     }
-    response.write(
-      lambdaResponse.isBase64Encoded
-        ? Buffer.from(lambdaResponse.body, "base64")
-        : lambdaResponse.body
-    );
+
+    if (lambdaResponse.body) {
+      response.write(
+        lambdaResponse.isBase64Encoded
+          ? Buffer.from(lambdaResponse.body, "base64")
+          : lambdaResponse.body
+      );
+    }
     response.end();
   }
 }


### PR DESCRIPTION
Currently, you must provide a body in the response and a simple status code won't do.
I propose that the body is optional, allowing simple status codes like 300's and 201 to have no body defined.

https://github.com/netlify/netlify-lambda/issues/91