### PR TITLE
Clears the invocation timeout if the invocation is a success.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -135,12 +135,20 @@ function createHandler(dir, static, timeout) {
       { clientContext: buildClientContext(request.headers) || {} },
       callback
     );
+
+    var invocationTimeoutRef = null
+    
     Promise.race([
       promiseCallback(promise, callback),
-      setTimeout(function() {
-        handleInvocationTimeout(response, timeout)
-      }, timeout * 1000)
-    ])
+      new Promise(function(resolve) {
+        invocationTimeoutRef = setTimeout(function() {
+          handleInvocationTimeout(response, timeout)
+          resolve()
+        }, timeout * 1000)
+      })
+    ]).finally(() => {
+      clearTimeout(invocationTimeoutRef)
+    })
   };
 }
 


### PR DESCRIPTION
This resolves #120 which caused the locally served lambda to crash after its first invocation. This was because the invocation timeout wasn't being cleared, which caused the timeout error handler to call `response.write` after the function was finished. 

This PR resolves the issue by capturing the timeout identifier and calling `clearTimeout` after the `Promise.race` has resolved.