### PR TITLE
Fix how NODE_ENV is being handled

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -68,8 +68,14 @@ function webpackConfig(dir, additionalConfig) {
     defineEnv['process.env.' + key] = JSON.stringify(envConfig[key]);
   });
 
+  // Keep the same NODE_ENV if it was specified
+  var nodeEnv = process.env.NODE_ENV || 'production'
+
+  // Set webpack mode based on the nodeEnv
+  var webpackMode = ['production', 'development'].includes(nodeEnv) ? nodeEnv : 'none'
+
   var webpackConfig = {
-    mode: 'production',
+    mode: webpackMode,
     resolve: {
       extensions: ['.wasm', '.mjs', '.js', '.json', '.ts']
     },
@@ -98,6 +104,9 @@ function webpackConfig(dir, additionalConfig) {
       path: functionsPath,
       filename: '[name].js',
       libraryTarget: 'commonjs'
+    },
+    optimization: {
+      nodeEnv
     },
     devtool: false
   };


### PR DESCRIPTION
This solves https://github.com/netlify/netlify-lambda/issues/119

If a standard NODE_ENV value is specified (production or development), let it pass through and set the mode accordingly. If a non-standard NODE_ENV is specified, let is pass through and set the Webpack mode to none.