### PR TITLE
Serve Jekyll static site too

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -175,7 +175,7 @@ exports.listen = function(port, static, timeout) {
     res.status(204).end();
   });
   
-  app.use(express.static('_site'))
+  app.use(express.static('_site', { 'extensions': ['html','htm'] }))
   app.all('/.netlify/*', createHandler(dir, static, timeout));
 
   app.listen(port, function(err) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -174,7 +174,9 @@ exports.listen = function(port, static, timeout) {
   app.get('/favicon.ico', function(req, res) {
     res.status(204).end();
   });
-  app.all('*', createHandler(dir, static, timeout));
+  
+  app.use(express.static('_site'))
+  app.all('/.netlify/*', createHandler(dir, static, timeout));
 
   app.listen(port, function(err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commander": "^2.17.1",
     "express": "^4.16.3",
     "express-logging": "^1.1.1",
+    "express-static": "^1.2.6",
     "jwt-decode": "^2.2.0",
     "toml": "^2.3.3",
     "webpack": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,13 @@ express-logging@^1.1.1:
   dependencies:
     on-headers "^1.0.0"
 
+express-static@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/express-static/-/express-static-1.2.6.tgz#567aab6ba808386936b8c17bb0a90f6f61d0db4f"
+  integrity sha512-pmp8fSe+bCxGCTk5+X6HzIF2APYMvrAq3Y7sT/WOELc0JZZxJhMTVgCbxcoUgMRBSqnQ9EfTw/Uv3J1ONoIAuA==
+  dependencies:
+    mime2 latest
+
 express@^4.16.3:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
@@ -3869,6 +3876,11 @@ mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
   dependencies:
     mime-db "~1.37.0"
+
+mime2@latest:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/mime2/-/mime2-0.0.9.tgz#507e3b3b370deb947c3b47a4ff544c33b7e1a4eb"
+  integrity sha512-19HM8Rpaqy7kEtupNI+XXUgh+dkPWQUpExLHVWntk6QySTUn0VKpn3kEe41K7DJh+wCYN1t93oak63jURqRW0A==
 
 mime@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Jekyll users have CORS issues running `jekyll serve` and `netlify-lambda serve` locally in parallel. Also function URLs need to be different between local dev (`localhost:9000/.netlify/functions/`) vs production (`/.netlify/functions/`). At least I couldn't figure this out. Documentation does not mention Jekyll either.

This little hack serves a local Jekyll site (under `_site`) *and* Netlify functions (with URLs `/.netlify/*`). Should help all Jekyll users to develop Netlify functions.

Maybe too hard-coded/hacky, but hopefully a start.