### PR TITLE
Resolve plugins and loaders

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -37,13 +37,13 @@ function webpackConfig(dir, additionalConfig) {
   var babelOpts = { cacheDirectory: true };
   if (!haveBabelrc(dir)) {
     babelOpts.presets = [
-      ['@babel/preset-env', { targets: { node: getBabelTarget(envConfig) } }]
+      [require.resolve('@babel/preset-env'), { targets: { node: getBabelTarget(envConfig) } }]
     ];
 
     babelOpts.plugins = [
-      '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-transform-object-assign',
-      '@babel/plugin-proposal-object-rest-spread'
+      require.resolve('@babel/plugin-proposal-class-properties'),
+      require.resolve('@babel/plugin-transform-object-assign'),
+      require.resolve('@babel/plugin-proposal-object-rest-spread')
     ];
   }
 
@@ -87,7 +87,7 @@ function webpackConfig(dir, additionalConfig) {
             `(node_modules|bower_components|${testFilePattern})`
           ),
           use: {
-            loader: 'babel-loader',
+            loader: require.resolve('babel-loader'),
             options: babelOpts
           }
         }


### PR DESCRIPTION
In one of my projects I started to get errors saying that `babel-loader` was not found etc. I could solve this locally by resolving them with `require.resolve`

Could maybe also fix #66