### PR TITLE
chore: whitelist files published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "scripts": {
     "test": "jest"
   },
+  "files": [
+    "lib/*.js",
+    "!lib/*.spec.js",
+    "bin/*.js"
+  ],
   "author": "Mathias Biilmann Christensen",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
There's some files published to npm that don't have to.
node_modules is slow enough as-is, so i'd encourage everyone to not publish files that are not used anyway.

I added a `files` whitelist to `package.json` to ignore the github configuration and test files.

An alternative would've been `.npmignore`, but once that exists, the `.gitignore` is ignored - so i'd rather do whitelisting via `files` than blacklisting via `.gitignore`.