### PR TITLE
refactor: change order of webpack stats logging and server setup

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -27,19 +27,18 @@ program
   .action(function(cmd, options) {
     console.log("netlify-lambda: Starting server");
     var static = Boolean(program.static);
-    var server = serve.listen(program.port || 9000, static, Number(program.timeout) || 10);
     if (static) return; // early terminate, don't build
     build.watch(cmd, program.config, function(err, stats) {
       if (err) {
         console.error(err);
         return;
       }
-
+      
+      console.log(stats.toString({ color: true }));
+      var server = serve.listen(program.port || 9000, static, Number(program.timeout) || 10);
       stats.compilation.chunks.forEach(function(chunk) {
         server.clearCache(chunk.name);
       });
-
-      console.log(stats.toString({ color: true }));
     });
   });
 


### PR DESCRIPTION
this logs the `port` the dev server listens to last, after the webpack stats output - e.g.

```bash
$ netlify-lambda serve --config webpack.lambda.js src/functions
netlify-lambda: Starting server
Hash: 01b6293f383c43ad6404
Version: webpack 4.29.6
Time: 2443ms
Built at: 04/16/2019 8:29:24 PM
     Asset      Size  Chunks             Chunk Names
graphql.js  1.23 MiB       0  [emitted]  graphql
Entrypoint graphql = graphql.js
 [46] ~projects/paderbornjs/site/node_modules/node-fetch/lib/index.mjs 39.6 KiB {0} [built]
 [56] ~projects/paderbornjs/site/node_modules/apollo-server-env/dist/index.js 396 bytes {0} [built]
 [77] ~projects/paderbornjs/site/node_modules/apollo-server-errors/dist/index.js 5.7 KiB {0} [built]
 [78] ~projects/paderbornjs/site/node_modules/graphql-tools/dist/makeExecutableSchema.js 4.35 KiB {0} [built]
 [96] ~projects/paderbornjs/site/node_modules/apollo-server-core/dist/index.js 2.08 KiB {0} [built]
 [98] ~projects/paderbornjs/site/node_modules/graphql-tools/dist/schemaVisitor.js 27.5 KiB {0} [built]
[137] ~projects/paderbornjs/site/node_modules/apollo-server-core/dist/utils/runtimeSupportsUploads.js 737 bytes {0} [built]
[152] ~projects/paderbornjs/site/node_modules/graphql-upload/lib/index.mjs + 5 modules 13.3 KiB {0} [built]
      | ~projects/paderbornjs/site/node_modules/graphql-upload/lib/index.mjs 139 bytes [built]
      | ~projects/paderbornjs/site/node_modules/graphql-upload/lib/GraphQLUpload.mjs 389 bytes [built]
      | ~projects/paderbornjs/site/node_modules/graphql-upload/lib/processRequest.mjs 7.21 KiB [built]
      | ~projects/paderbornjs/site/node_modules/graphql-upload/lib/graphqlUploadKoa.mjs 382 bytes [built]
      | ~projects/paderbornjs/site/node_modules/graphql-upload/lib/graphqlUploadExpress.mjs 640 bytes [built]
      | ~projects/paderbornjs/site/node_modules/fs-capacitor/lib/index.mjs 4.55 KiB [built]
[157] ~projects/paderbornjs/site/node_modules/apollo-server-lambda/dist/index.js 1.06 KiB {0} [built]
[171] ~projects/paderbornjs/site/node_modules/apollo-server-core/dist/graphqlOptions.js 1.02 KiB {0} [built]
[179] ~projects/paderbornjs/site/node_modules/graphql-tools/dist/index.js 459 bytes {0} [built]
[232] ~projects/paderbornjs/site/node_modules/graphql-iso-date/dist/index.js 741 bytes {0} [built]
[234] ~projects/paderbornjs/site/packages/schema/schema.graphql 8.54 KiB {0} [built]
[431] ~projects/paderbornjs/site/node_modules/apollo-server-lambda/dist/ApolloServer.js 5.22 KiB {0} [built]
[441] ./graphql.ts + 14 modules 10.1 KiB {0} [built]
      | ./graphql.ts 686 bytes [built]
      | ../resolvers/index.ts 412 bytes [built]
      | ../utils/createContext.ts 760 bytes [built]
      | ../resolvers/event/talks.ts 209 bytes [built]
      | ../resolvers/query/organizers.ts 401 bytes [built]
      | ../resolvers/query/upcomingEvents.ts 540 bytes [built]
      | ../loaders/EventTalksLoader.ts 853 bytes [built]
      | ../services/GithubService.ts 893 bytes [built]
      | ../services/MeetupService.ts 959 bytes [built]
      | ../services/TwitterService.ts 1.61 KiB [built]
      | ../utils/getEnvironmentVariable.ts 195 bytes [built]
      | ../constants.ts 105 bytes [built]
      | ../utils/hasMilestone.ts 555 bytes [built]
      | ../utils/issueToTalk.ts 1.59 KiB [built]
      | ../utils/getResponseCache.ts 523 bytes [built]
    + 427 hidden modules
Lambda server is listening on 9000
```