### PR TITLE
Add flag to not use relative .babelrc config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+.vscode/
 *.swp

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ The additional webpack config will be merged into the default config via [webpac
 
 The default webpack configuration uses `babel-loader` with a [few basic settings](https://github.com/netlify/netlify-lambda/blob/master/lib/build.js#L19-L33).
 
-However, if any `.babelrc` is found in the directory `netlify-lambda` is run from, or [folders above it](https://github.com/netlify/netlify-lambda/pull/92) (useful for monorepos), it will be used instead of the default one.
+However, if any `.babelrc` is found in the directory `netlify-lambda` is run from, or [folders above it](https://github.com/netlify/netlify-lambda/pull/92) (useful for monorepos), it will be used instead of the default one. 
+
+It is possible to disable this behaviour by passing `--babelrc false`.  
 
 If you need to run different babel versions for your lambda and for your app, [check this issue](https://github.com/netlify/netlify-lambda/issues/34) to override your webpack babel-loader.
 
@@ -393,6 +395,7 @@ There are additional CLI options:
 -p --port
 -s --static
 -t --timeout
+-b --babelrc
 ```
 
 ### --config option
@@ -421,6 +424,12 @@ The serving port can be changed with the `-p`/`--port` option.
 ### --static option
 
 If you need an escape hatch and are building your lambda in some way that is incompatible with our build process, you can skip the build with the `-s` or `--static` flag. [More info here](https://github.com/netlify/netlify-lambda/pull/62).
+
+### --babelrc
+
+Defaults to `true`
+
+Use a `.babelrc` found in the directory `netlify-lambda` is run from. This can be useful when you have conflicting babel-presets, more info [here](#babel-configuration)
 
 ## Netlify Identity
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -16,6 +16,7 @@ var serve = require("../lib/serve");
 program.version(pkg.version);
 
 const stringBooleanToBoolean = val => {
+  console.log({val});
   if (typeof val !== 'string' && (val !== 'true' || val !== 'false')) {
     throw Error(`Incorrect string value: ${val}`);
   }
@@ -26,7 +27,7 @@ const stringBooleanToBoolean = val => {
 program
   .option("-c --config <webpack-config>", "additional webpack configuration")
   .option("-p --port <port>", "port to serve from (default: 9000)")
-  .option("-b --babelrc babelrc>", "use .babelrc in root (default: true)", stringBooleanToBoolean)
+  .option("-b --babelrc <babelrc>", "use .babelrc in root (default: true)", stringBooleanToBoolean)
   .option(
     "-t --timeout <timeout>",
     "function invocation timeout in seconds (default: 10)"

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -15,9 +15,18 @@ var serve = require("../lib/serve");
 
 program.version(pkg.version);
 
+const stringBooleanToBoolean = val => {
+  if (typeof val !== 'string' && (val !== 'true' || val !== 'false')) {
+    throw Error(`Incorrect string value: ${val}`);
+  }
+
+  return val === 'true';
+};
+
 program
   .option("-c --config <webpack-config>", "additional webpack configuration")
   .option("-p --port <port>", "port to serve from (default: 9000)")
+  .option("-b --babelrc <no-babelrc>", "use .babelrc in root (default: true)", stringBooleanToBoolean)
   .option(
     "-t --timeout <timeout>",
     "function invocation timeout in seconds (default: 10)"
@@ -57,8 +66,10 @@ program
   .description("build functions")
   .action(function(cmd, options) {
     console.log("netlify-lambda: Building functions");
+
+    const { config: userWebpackConfig, babelrc: useBabelrc = true} = program;
     build
-      .run(cmd, program.config)
+      .run(cmd, { userWebpackConfig, useBabelrc})
       .then(function(stats) {
         console.log(stats.toString({ color: true }));
       })

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -26,7 +26,7 @@ const stringBooleanToBoolean = val => {
 program
   .option("-c --config <webpack-config>", "additional webpack configuration")
   .option("-p --port <port>", "port to serve from (default: 9000)")
-  .option("-b --babelrc <no-babelrc>", "use .babelrc in root (default: true)", stringBooleanToBoolean)
+  .option("-b --babelrc babelrc>", "use .babelrc in root (default: true)", stringBooleanToBoolean)
   .option(
     "-t --timeout <timeout>",
     "function invocation timeout in seconds (default: 10)"

--- a/lib/build.js
+++ b/lib/build.js
@@ -31,7 +31,7 @@ function haveBabelrc(functionsDir) {
   );
 }
 
-function webpackConfig(dir, additionalConfig) {
+function webpackConfig(dir, {userWebpackConfig, useBabelrc}) {
   var config = conf.load();
   var envConfig = conf.loadContext(config).environment;
   var babelOpts = { cacheDirectory: true };
@@ -88,7 +88,7 @@ function webpackConfig(dir, additionalConfig) {
           ),
           use: {
             loader: require.resolve('babel-loader'),
-            options: babelOpts
+            options: {...babelOpts, babelrc: useBabelrc}
           }
         }
       ]
@@ -129,8 +129,8 @@ function webpackConfig(dir, additionalConfig) {
       `
     );
   }
-  if (additionalConfig) {
-    var webpackAdditional = require(path.join(process.cwd(), additionalConfig));
+  if (userWebpackConfig) {
+    var webpackAdditional = require(path.join(process.cwd(), userWebpackConfig));
 
     return merge.smart(webpackConfig, webpackAdditional);
   }


### PR DESCRIPTION
Based upon this issue https://github.com/netlify/netlify-lambda/issues/152

I'm not sure how this package is tested locally but my process was: 

`yarn add babel-preset-gatsby`

add a .babelrc in the root
```json
{
  "presets": ["babel-preset-gatsby"],
}
```

add `functions/handle.js` file with basic lambda 
```javacript
exports.handler = async () => {
  return {
    statusCode: 200,
    body: 'yay'
  }
}
```


add `netlify.toml` 
```toml
[build]
  functions = "./output"
```

to have the command error run:  `bin/cmd.js build functions/`

You should get and error that looks something along the lines of this: 
```
`babel-preset-gatsby` has been loaded, which consumes config generated by the Gatsby CLI.
```

to have the command pass run: `bin/cmd.js build --babelrc false functions/`


### Can't you just set this babelrc: false opt in a custom webpack config?
I tried that but found that the webpackmerge library doesn't dedupe the two babel-loader rules so you end up with two babel-loader configs, one of which includes the root .babelrc