### PR TITLE
Fix broken watch command

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -52,7 +52,9 @@ program
       startServer();
       return; // early terminate, don't build
     };
-    build.watch(cmd, program.config, function(err, stats) {
+  
+    const { config: userWebpackConfig, babelrc: useBabelrc = true} = program;
+    build.watch(cmd, {userWebpackConfig, useBabelrc}, function(err, stats) {
       if (err) {
         console.error(err);
         return;


### PR DESCRIPTION
The watch command needs the same additionalConfig parameters as the build command.

This fixes the following error:
TypeError: Cannot destructure property `userWebpackConfig` of 'undefined' or 'null'.