### PR TITLE
fix: proritize server builds over browser for packages

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -77,7 +77,8 @@ function webpackConfig(dir, {userWebpackConfig, useBabelrc} = {}) {
   var webpackConfig = {
     mode: webpackMode,
     resolve: {
-      extensions: ['.wasm', '.mjs', '.js', '.json', '.ts']
+      extensions: ['.wasm', '.mjs', '.js', '.json', '.ts'],
+      mainFields: ['module', 'main']
     },
     module: {
       rules: [


### PR DESCRIPTION
This PR prioritizes the `module` and `main` fields over the `browser` field, which Webpack uses by default, but is often incompatible with Node.

Closes #138 