### PR TITLE
fix empty lambda warning

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -45,12 +45,13 @@ function createCallback(response) {
       );
     } else {
       if (
-        process.env.CONTEXT !== "production" ||
+        response.statusCode !== 204 &&
+        process.env.CONTEXT !== "production" &&
         !process.env.SILENCE_EMPTY_LAMBDA_WARNING
       )
         console.log(
           `Your lambda function didn't return a body, which may be a mistake. Check our Usage docs for examples (https://github.com/netlify/netlify-lambda#usage). 
-          If this is intentional, you can silence this warning by setting process.ENV.SILENCE_EMPTY_LAMBDA_WARNING to a truthy value or process.env.CONTEXT to 'production'`
+          If this is intentional, you can silence this warning by setting process.env.SILENCE_EMPTY_LAMBDA_WARNING to a truthy value or process.env.CONTEXT to 'production'`
         );
     }
     response.end();


### PR DESCRIPTION
This PR does two things: 

1. It fixes the logic for determining whether to log out the "empty lambda" warning -- there was mistakenly an OR where there should have been an AND. 
2. It bypasses the warning if the `statusCode` is set to `204`, because a `204` response means `no content` and shouldn't have a body (in fact supplying a body for a 204 can cause bugs).