### PR TITLE
fix: recognize package.json in the root target also

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -23,7 +23,7 @@ exports.run = async function(dir) {
     directory = functionsPath;
   }
 
-  const findJSFiles = ["*/package.json", "!node_modules", "!**/node_modules"];
+  const findJSFiles = ["**/package.json", "!node_modules", "!**/node_modules"];
   const foldersWithDeps = await globby(findJSFiles, { cwd: directory });
 
   const folders = foldersWithDeps


### PR DESCRIPTION
This recognizes the root package.json as well as sub directories containing package.json

closes #174