### PR TITLE
Document minimum Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Netlify Lambda
 
+[![Node](https://img.shields.io/node/v/netlify-lambda.svg?logo=node.js)](https://www.npmjs.com/package/netlify-lambda)
+
 This is an optional tool that helps with building or locally developing [Netlify Functions](https://www.netlify.com/docs/functions/) with a simple webpack/babel build step. For function folders, there is also a small utility to install function folder dependencies.
 
 The goal is to make it easy to write Lambda's with transpiled JS/TypeScript features and imported modules.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "auto-changelog": "^1.13.0",
     "gh-release": "^3.5.0",
     "jest": "^23.6.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
Our minimum Node.js version is `8.0.0` due to the `globby` package using that version. We should document it both for our users and the contributors.