### PR TITLE
Add `package-lock.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .vscode/
 *.swp
+package-lock.json


### PR DESCRIPTION
We can't assume `package-lock.json` is part of the user/global `.gitignore` because some libraries push this file to git. So we should add it to `.gitignore`.