### PR TITLE
Add extra error messaging

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -59,6 +59,7 @@ function webpackConfig(dir, { userWebpackConfig, useBabelrc } = {}) {
       should be different. They are both set to ${dirPath}.
 
       This is a common mistake for people switching from Netlify Dev to netlify-lambda. For an easy fix, change your functions key inside netlify.toml to something else, like "functions-build".
+      You will then need to build your functions to that directory before they will work locally and the built functions will also need to be pushed to your repo.
       For more info, check https://github.com/netlify/netlify-lambda#usage
       `
     );


### PR DESCRIPTION
Add a little more explanation to netlify-lambda build error.

This was my first pass at some additional error messaging.
For me it was confusing seeing this error and not knowing I needed to have a separate src and dist directory and that the netlify.toml file only needed to be told about the dist. I assumed netlify-lambda did the build process for you and only needed the src directory.