### PR TITLE
Enable .tsx files

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -82,13 +82,13 @@ function webpackConfig(dir, { userWebpackConfig, useBabelrc } = {}) {
   var webpackConfig = {
     mode: webpackMode,
     resolve: {
-      extensions: [".wasm", ".mjs", ".js", ".json", ".ts"],
+      extensions: [".wasm", ".mjs", ".js", ".json", ".ts", ".tsx"],
       mainFields: ["module", "main"]
     },
     module: {
       rules: [
         {
-          test: /\.(m?js|ts)?$/,
+          test: /\.(m?js|tsx?)?$/,
           exclude: new RegExp(
             `(node_modules|bower_components|${testFilePattern})`
           ),
@@ -118,8 +118,8 @@ function webpackConfig(dir, { userWebpackConfig, useBabelrc } = {}) {
     devtool: false
   };
   fs.readdirSync(dirPath).forEach(function(file) {
-    if (file.match(/\.(m?js|ts)$/)) {
-      var name = file.replace(/\.(m?js|ts)$/, "");
+    if (file.match(/\.(m?js|tsx?)$/)) {
+      var name = file.replace(/\.(m?js|tsx?)$/, "");
       if (!name.match(new RegExp(testFilePattern))) {
         webpackConfig.entry[name] = "./" + file;
       }
@@ -129,7 +129,7 @@ function webpackConfig(dir, { userWebpackConfig, useBabelrc } = {}) {
     console.warn(
       `
       ---Start netlify-lambda notification---
-      WARNING: No valid single functions files (ending in .mjs, .js or .ts) were found. 
+      WARNING: No valid single functions files (ending in .mjs, .js, .ts or .tsx) were found. 
       This could be because you have nested them in a folder.
       If this is expected (e.g. you have a zipped function built somewhere else), you may ignore this.
       ---End netlify-lambda notification---


### PR DESCRIPTION
In my (TypeScript) netlify function I'm using `renderToStaticMarkup` from `react-dom/server` to create HTML to send an email, which means my files need to contain JSX. TypeScript (infuriatingly) [refuses to parse JSX unless the file extension is `.tsx`](https://www.typescriptlang.org/docs/handbook/jsx.html#basic-usage) and the webpack babel loader isn't set up to match against `.tsx` files. This PR fixes it.

Let me know any questions. Cheers!