### PR TITLE
Fix redirecting link in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ By default it just runs on the functions folder specified in `netlify.toml`. Her
 ```js
 // package.json
 {
-   "dependencies": { // you probably don't want it in devDependencies! This is a common gotcha https://www.netlify.com/docs/build-gotchas/#devdependencies
+   "dependencies": { // you probably don't want it in devDependencies! This is a common gotcha https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-environment
        "netlify-lambda": "^1.6.0"
    },
    "scripts": {


### PR DESCRIPTION
A [link](https://www.netlify.com/docs/build-gotchas/#devdependencies) in the README is broken because it seems to be pointing to a prior incarnation of the docs site, and redirecting to an analogous section of the new docs site. 

This PR updates it to point directly to the [redirect URL](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-environment).