### PR TITLE
Make "nodejs12.x" valid build runtime  and update matching.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -8,11 +8,15 @@ const testFilePattern = "\\.(test|spec)\\.?";
 
 // custom babel target for each node version
 function getBabelTarget(envConfig) {
+  const nodeMajorVersionPattern = /(?<=nodejs)\d*/;
   var key = "AWS_LAMBDA_JS_RUNTIME";
-  var runtimes = ["nodejs8.15.0", "nodejs6.10.3"];
-  var current = envConfig[key] || process.env[key] || "nodejs8.15.0";
-  var unknown = runtimes.indexOf(current) === -1;
-  return unknown ? "8.15.0" : current.replace(/^nodejs/, "");
+  var runtimes = ["nodejs12.x", "nodejs8.15.0", "nodejs6.10.3"];
+  var current = envConfig[key] || process.env[key] || "nodejs12.x"; // default as at 2020_02
+  var currentMajorRelease = current.match(nodeMajorVersionPattern)[0];
+  var currentIsValid = runtimes.some(
+    r => r.match(nodeMajorVersionPattern)[0] === currentMajorRelease
+  );
+  return currentIsValid ? currentMajorRelease : "12";
 }
 
 function haveBabelrc(functionsDir) {


### PR DESCRIPTION
This PR addresses https://github.com/netlify/netlify-lambda/issues/213 and updates the current runtime string matching to accommodate the ``nodejs12.x`` syntax advocated in the latest Netlify docs.