### PR TITLE
Upgrade Babel to latest version to prevent "Unknown helper createSuper" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-object-assign": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "^8.1.0",
     "body-parser": "^1.18.3",
     "commander": "^2.17.1",
     "express": "^4.16.3",


### PR DESCRIPTION
Babel recently introduced an issue that occurs if the versions of `@babel/core` and `@babel/plugin-transform-classes` are out of sync. To the end user, it causes a hard-to-diagnose "Unknown helper createSuper" error at build.

The fix is simple: upgrade to the latest version of Babel (`8.1.0`).

cc. @sw-yx 