### PR TITLE
Update readme to include common error scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ export async function handler(event, context) {
   - the blogposts at the bottom of this README
   
   </details>
+  
+#### Common errors during build
+
+If you face a lot of errors related to missing dependencies or errors stating `Critical dependency: the request of a dependency is an expression`, then it might be related to the fact that you run npm modules that require node-externals. In this case simply add a webpack configuration like below:
+
+```
+const nodeExternals = require('webpack-node-externals');
+
+module.exports = {
+  externals: [nodeExternals()],
+};
+```
+
+More info on making netlify-lambda work with webpack [below](https://github.com/netlify/netlify-lambda/blob/master/README.md#webpack-configuration).
 
 ### `netlify-lambda serve` (legacy command)
 


### PR DESCRIPTION
I'm getting a lot of questions regarding the netlify-lambda tool. While its actually less related to Netlify Lambda, but more to webpack and serverless in general, it does kill the experience for new people that are trying Netlify Functions when they face errors during the build stage.

In a default setup with functions its highly likely that people will use SDK's like Mongoose, Firebase, etc. Though its stated in this readme how to fix it for Firebase. Its not clear that adding `webpack-node-externals` fixes other issues as-well and its also not located on the `netlify-lambda build` section. People follow the docs step by step and so they get stuck when they face errors on this build stage. Solving this error is not clear for people that have no experience with Webpack and serverless hence this addition