### PR TITLE
fix(webpack): use webpack-merge v4 to support merge.smart and node 10

### DIFF
--- a/lib/build.spec.js
+++ b/lib/build.spec.js
@@ -65,5 +65,29 @@ describe('build', () => {
         }),
       ).rejects.toThrow('Cannot find module');
     });
+
+    it('should merge webpack custom config', async () => {
+      const script = `module.exports = () => console.log("hello world")`;
+      setupFunction(script, 'index.js');
+
+      const webpackConfig = `module.exports = { resolve: { extensions: ['.custom'] } }`;
+      const customWebpackConfigDir = path.join(buildTemp, 'webpack');
+      const userWebpackConfig = path.join(customWebpackConfigDir, 'webpack.js');
+      fs.mkdirSync(customWebpackConfigDir, { recursive: true });
+      fs.writeFileSync(userWebpackConfig, webpackConfig);
+
+      const stats = await build.run(functions, {
+        userWebpackConfig,
+      });
+      expect(stats.compilation.errors).toHaveLength(0);
+      expect(stats.compilation.options.resolve.extensions).toEqual([
+        '.wasm',
+        '.mjs',
+        '.js',
+        '.json',
+        '.ts',
+        '.custom',
+      ]);
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2767,6 +2767,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
@@ -3325,16 +3334,6 @@
             "strip-ansi": "^6.0.0"
           }
         }
-      }
-    },
-    "clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
       }
     },
     "co": {
@@ -4890,6 +4889,12 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -8579,6 +8584,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10170,14 +10181,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11445,7 +11448,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -11685,12 +11692,11 @@
       }
     },
     "webpack-merge": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.0.9.tgz",
-      "integrity": "sha512-P4teh6O26xIDPugOGX61wPxaeP918QOMjmzhu54zTVcLtOS28ffPWtnv+ilt3wscwBUCL2WNMnh97XkrKqt9Fw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "requires": {
-        "clone-deep": "^4.0.1",
-        "wildcard": "^2.0.0"
+        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {
@@ -11835,11 +11841,6 @@
           }
         }
       }
-    },
-    "wildcard": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jwt-decode": "^2.2.0",
     "toml": "^3.0.0",
     "webpack": "^4.43.0",
-    "webpack-merge": "^5.0.9"
+    "webpack-merge": "^4.2.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.0.0",


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-lambda/issues/249

Reverted the major version upgrade for `webpack-merge` until I can find a better fix.
According to the [changelog](https://github.com/survivejs/webpack-merge/blob/master/CHANGELOG.md#503--2020-07-06) the `smart` method was dropped and we also need to switch to named imports.

Also added a test case.