### PR TITLE
Update .babelrc example for use with TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,17 +405,17 @@ You may also want to add `typescript @types/node @types/aws-lambda`.
 
 2. Create a Babel config file, e.g. `.babelrc`:
 
-```diff
+```json
 {
   "presets": [
-    "@babel/preset-typescript"
+    "@babel/preset-typescript",
     [
-		  "@babel/preset-env",
-		  {
-		    "targets": {
-		      "node": true
-		    }
-		  }
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": true
+        }
+      }
     ]
   ],
   "plugins": [

--- a/README.md
+++ b/README.md
@@ -408,8 +408,15 @@ You may also want to add `typescript @types/node @types/aws-lambda`.
 ```diff
 {
   "presets": [
-    "@babel/preset-typescript",
-    "@babel/preset-env"
+    "@babel/preset-typescript"
+    [
+		  "@babel/preset-env",
+		  {
+		    "targets": {
+		      "node": true
+		    }
+		  }
+    ]
   ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",


### PR DESCRIPTION
Using the .babelrc example from "Using with Typescript" in the README breaks async function.

Error: `{"errorType":"ReferenceError","errorMessage":"regeneratorRuntime is not defined"}`

Relevant issues:
- https://github.com/babel/babel/issues/9849
- https://binyamin.medium.com/enabling-async-await-and-generator-functions-in-babel-node-and-express-71e941b183e2

Fix: Add config object in `@babel/preset-env`