### PR TITLE
webpack-merge v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ module.exports = {
 };
 ```
 
-The additional webpack config will be merged into the default config via [webpack-merge's](https://www.npmjs.com/package/webpack-merge) `merge.smart` method.
+The additional webpack config will be merged into the default config via [webpack-merge's](https://www.npmjs.com/package/webpack-merge) `merge` method.
 
 ### Babel configuration
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var conf = require('./config');
 var webpack = require('webpack');
-var merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const findUp = require('find-up');
 
 const readdir = util.promisify(fs.readdir);
@@ -198,7 +198,7 @@ async function webpackConfig(
   if (userWebpackConfig) {
     var webpackAdditional = require(path.join(cwd, userWebpackConfig));
 
-    return merge.smart(webpackConfig, webpackAdditional);
+    return merge(webpackConfig, webpackAdditional);
   }
 
   return webpackConfig;

--- a/lib/build.spec.js
+++ b/lib/build.spec.js
@@ -105,28 +105,58 @@ describe('build', () => {
       ).rejects.toThrow('Cannot find module');
     });
 
-    it('should merge webpack custom config', async () => {
-      const script = `module.exports = () => console.log("hello world")`;
-      await writeFileInFunctions(script, 'index.js');
+    describe('webpack custom config merge', () => {
+      it('should merge plugins', async () => {
+        const script = `module.exports = () => console.log("hello world")`;
+        await writeFileInFunctions(script, 'index.js');
 
-      const webpackConfig = `module.exports = { resolve: { extensions: ['.custom'] } }`;
-      const userWebpackConfig = await writeFileInBuild(
-        webpackConfig,
-        'webpack/webpack.js',
-      );
+        const webpackConfig = `
+        const webpack = require('webpack');
+        module.exports = { plugins: [new webpack.EnvironmentPlugin(['NODE_ENV'])] };
+        `;
 
-      const stats = await build.run(functions, {
-        userWebpackConfig,
+        const suffix = expect.getState().currentTestName.replace(/\s+/g, '_');
+        const userWebpackConfig = await writeFileInBuild(
+          webpackConfig,
+          `webpack/webpack_${suffix}.js`,
+        );
+
+        const stats = await build.run(functions, {
+          userWebpackConfig,
+        });
+        expect(stats.compilation.errors).toHaveLength(0);
+        expect(stats.compilation.options.plugins).toHaveLength(3);
+        expect(
+          stats.compilation.options.plugins.map(
+            (plugin) => plugin.constructor.name,
+          ),
+        ).toEqual(['IgnorePlugin', 'DefinePlugin', 'EnvironmentPlugin']);
       });
-      expect(stats.compilation.errors).toHaveLength(0);
-      expect(stats.compilation.options.resolve.extensions).toEqual([
-        '.wasm',
-        '.mjs',
-        '.js',
-        '.json',
-        '.ts',
-        '.custom',
-      ]);
+
+      it('should merge resolve extensions', async () => {
+        const script = `module.exports = () => console.log("hello world")`;
+        await writeFileInFunctions(script, 'index.js');
+
+        const webpackConfig = `module.exports = { resolve: { extensions: ['.custom'] } }`;
+        const suffix = expect.getState().currentTestName.replace(/\s+/g, '_');
+        const userWebpackConfig = await writeFileInBuild(
+          webpackConfig,
+          `webpack/webpack_${suffix}.js`,
+        );
+
+        const stats = await build.run(functions, {
+          userWebpackConfig,
+        });
+        expect(stats.compilation.errors).toHaveLength(0);
+        expect(stats.compilation.options.resolve.extensions).toEqual([
+          '.wasm',
+          '.mjs',
+          '.js',
+          '.json',
+          '.ts',
+          '.custom',
+        ]);
+      });
     });
 
     describe('babel config file resolution', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "jwt-decode": "^3.0.0",
         "toml": "^3.0.0",
         "webpack": "^4.43.0",
-        "webpack-merge": "^4.2.2"
+        "webpack-merge": "^5.8.0"
       },
       "bin": {
         "netlify-lambda": "bin/cmd.js"
@@ -4428,6 +4428,19 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -9752,7 +9765,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -12079,6 +12093,17 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14135,11 +14160,15 @@
       }
     },
     "node_modules/webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dependencies": {
-        "lodash": "^4.17.15"
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -14421,6 +14450,11 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -17933,6 +17967,16 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
       }
     },
     "co": {
@@ -21997,7 +22041,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -23824,6 +23869,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -25610,11 +25663,12 @@
       }
     },
     "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "requires": {
-        "lodash": "^4.17.15"
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
       }
     },
     "webpack-sources": {
@@ -25686,6 +25740,11 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jwt-decode": "^3.0.0",
     "toml": "^3.0.0",
     "webpack": "^4.43.0",
-    "webpack-merge": "^4.2.2"
+    "webpack-merge": "^5.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.0",


### PR DESCRIPTION
- [x] Upgrades [webpack-merge](https://github.com/survivejs/webpack-merge) to latest.
- [x] Add a test covering plugins merge.

Disclaimer: I did not reimplement `merge.smart` because we may not need it. I thought it would be better to keep it simple and in case someone has a special need then we work on the code to handle that instead of potentially add unnecessary code.