### PR TITLE
chore: remove unnecessary console.log

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -17,7 +17,6 @@ var install = require('../lib/install');
 program.version(pkg.version);
 
 const stringBooleanToBoolean = (val) => {
-  console.log({ val });
   if (typeof val !== 'string' && (val !== 'true' || val !== 'false')) {
     throw Error(`Incorrect string value: ${val}`);
   }


### PR DESCRIPTION
Running `netlify-lambda` with the `--babelrc` flag caused an extra log:

```bash
netlify-lambda serve functions --babelrc false

{ val: 'false' }
netlify-lambda: Starting server
```