### PR TITLE
chore: fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [10.x, '*']
-        exclude:
+        os: [ubuntu-latest]
+        node-version: [10, 12, 14, 16]
+        include:
           - os: macOS-latest
-            node-version: 10.x
+            node-version: 16
           - os: windows-latest
-            node-version: 10.x
+            node-version: 16
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
#### Summary

Fix the tests, by removing node 18 from the workflow. Webpack 4 does not support node 17 and up. So if we want to support node 17 and up we would need to update webpack.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/netlify-lambda/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
